### PR TITLE
Update jax and objax

### DIFF
--- a/bayesnewton/basemodels.py
+++ b/bayesnewton/basemodels.py
@@ -4,7 +4,6 @@ from .likelihoods import Gaussian, MultiLatentLikelihood
 from .kernels import Independent, Separable
 from jax import vmap
 from jax.lax import scan
-#from jax.ops import index, index_update
 from jax.scipy.linalg import cholesky, cho_factor, cho_solve
 from jax.lib import xla_bridge
 from .utils import (
@@ -195,9 +194,7 @@ class BaseModel(objax.Module):
 
     def group_natural_params(self, nat1, nat2, batch_ind=None):
         if (batch_ind is not None) and (batch_ind.shape[0] != self.num_data):
-            #nat1 = index_update(self.pseudo_likelihood.nat1, index[batch_ind], nat1)
             nat1 = self.pseudo_likelihood.nat1.at[batch_ind].set(nat1)
-            #nat2 = index_update(self.pseudo_likelihood.nat2, index[batch_ind], nat2)
             nat2 = self.pseudo_likelihood.nat2.at[batch_ind].set(nat2)
         return nat1, nat2
 
@@ -955,7 +952,6 @@ class SparseMarkovGaussianProcess(MarkovGaussianProcess):
         # nat2 = 1e-8 * eyes
 
         # initialise to match MarkovGP / GP on first step (when Z=X):
-        #nat2 = index_update(1e-8 * eyes, index[:-1, self.state_dim, self.state_dim], 1e-2)
         nat2 = (1e-8*eyes).at[:-1, self.state_dim, self.state_dim].set(1e-2)
 
         # initialise to match old implementation:

--- a/bayesnewton/basemodels.py
+++ b/bayesnewton/basemodels.py
@@ -4,7 +4,7 @@ from .likelihoods import Gaussian, MultiLatentLikelihood
 from .kernels import Independent, Separable
 from jax import vmap
 from jax.lax import scan
-from jax.ops import index, index_update
+#from jax.ops import index, index_update
 from jax.scipy.linalg import cholesky, cho_factor, cho_solve
 from jax.lib import xla_bridge
 from .utils import (
@@ -195,8 +195,10 @@ class BaseModel(objax.Module):
 
     def group_natural_params(self, nat1, nat2, batch_ind=None):
         if (batch_ind is not None) and (batch_ind.shape[0] != self.num_data):
-            nat1 = index_update(self.pseudo_likelihood.nat1, index[batch_ind], nat1)
-            nat2 = index_update(self.pseudo_likelihood.nat2, index[batch_ind], nat2)
+            #nat1 = index_update(self.pseudo_likelihood.nat1, index[batch_ind], nat1)
+            nat1 = self.pseudo_likelihood.nat1.at[batch_ind].set(nat1)
+            #nat2 = index_update(self.pseudo_likelihood.nat2, index[batch_ind], nat2)
+            nat2 = self.pseudo_likelihood.nat2.at[batch_ind].set(nat2)
         return nat1, nat2
 
     def conditional_posterior_to_data(self, batch_ind=None, post_mean=None, post_cov=None):
@@ -953,7 +955,8 @@ class SparseMarkovGaussianProcess(MarkovGaussianProcess):
         # nat2 = 1e-8 * eyes
 
         # initialise to match MarkovGP / GP on first step (when Z=X):
-        nat2 = index_update(1e-8 * eyes, index[:-1, self.state_dim, self.state_dim], 1e-2)
+        #nat2 = index_update(1e-8 * eyes, index[:-1, self.state_dim, self.state_dim], 1e-2)
+        nat2 = (1e-8*eyes).at[:-1, self.state_dim, self.state_dim].set(1e-2)
 
         # initialise to match old implementation:
         # nat2 = (1 / 99) * eyes

--- a/bayesnewton/inference.py
+++ b/bayesnewton/inference.py
@@ -1,7 +1,6 @@
 import objax
 import jax.numpy as np
 from jax import vmap
-#from jax.ops import index_update, index
 from .utils import (
     diag,
     transpose,
@@ -902,11 +901,8 @@ class QuasiNewton(QuasiNewtonBase, Newton):
         )
 
         if self.mean_prev.value.shape[0] != mean_f.shape[0]:
-            #B = index_update(self.hessian_approx.value, index[ind], B)
             B = self.hessian_approx.value.at[ind].set(B)
-            #jacobian = index_update(self.jacobian_prev.value, index[ind], jacobian)
             jacobian = self.jacobian_prev.value.at[ind].set(jacobian) 
-            #mean_f = index_update(self.mean_prev.value, index[ind], mean_f)
             mean_f = self.mean_prev.value.at[ind].set(mean_f)
 
         return mean_f, jacobian, B, (mean_f, jacobian, B)
@@ -953,11 +949,8 @@ class VariationalQuasiNewton(QuasiNewtonBase, VariationalInference):
         )
 
         if self.mean_prev.value.shape[0] != mean_f.shape[0]:
-            #B = index_update(self.hessian_approx.value, index[ind], B)
             B = self.hessian_approx.value.at[ind].set(B)
-            #jacobian = index_update(self.jacobian_prev.value, index[ind], jacobian)
             jacobian = self.jacobian_prev.value.at[ind].set(jacobian)
-            #mean_f = index_update(self.mean_prev.value, index[ind], mean_f)
             mean_f = self.mean_prev.value.at[ind].set(mean_f)
 
         return mean_f, jacobian, B[:, :self.func_dim, :self.func_dim], (mean_var, jacobian_mean_var, B)
@@ -1011,11 +1004,8 @@ class ExpectationPropagationQuasiNewton(QuasiNewtonBase, ExpectationPropagation)
         hessian = scale_factor @ B[:, :self.func_dim, :self.func_dim]
 
         if self.mean_prev.value.shape[0] != cav_mean_f.shape[0]:
-            #B = index_update(self.hessian_approx.value, index[ind], B)
             B = self.hessian_approx.value.at[ind].set(B)
-            #jacobian = index_update(self.jacobian_prev.value, index[ind], jacobian)
             jacobian = self.jacobian_prev.value.at[ind].set(jacobian) 
-            #cav_mean_f = index_update(self.mean_prev.value, index[ind], cav_mean_f)
             cav_mean_f = self.mean_prev.value.at[ind].set(cav_mean_f)
 
 
@@ -1127,11 +1117,8 @@ class PosteriorLinearisation2ndOrderQuasiNewton(QuasiNewtonBase, PosteriorLinear
         )
 
         if self.mean_prev.value.shape[0] != mean_f.shape[0]:
-            #B = index_update(self.hessian_approx.value, index[ind], B)
             B = self.hessian_approx.value.at[ind].set(B)
-            #jacobian = index_update(self.jacobian_prev.value, index[ind], jacobian)
             jacobian = self.jacobian_prev.value.at[ind].set(jacobian) 
-            #mean_f = index_update(self.mean_prev.value, index[ind], mean_f)
             mean_f = self.mean_prev.value.at[ind].set(mean_f)
 
         return mean_f, jacobian, B[:, :self.func_dim, :self.func_dim], (mean_var, jacobian_mean_var, B)

--- a/bayesnewton/inference.py
+++ b/bayesnewton/inference.py
@@ -1,7 +1,7 @@
 import objax
 import jax.numpy as np
 from jax import vmap
-from jax.ops import index_update, index
+#from jax.ops import index_update, index
 from .utils import (
     diag,
     transpose,
@@ -902,9 +902,12 @@ class QuasiNewton(QuasiNewtonBase, Newton):
         )
 
         if self.mean_prev.value.shape[0] != mean_f.shape[0]:
-            B = index_update(self.hessian_approx.value, index[ind], B)
-            jacobian = index_update(self.jacobian_prev.value, index[ind], jacobian)
-            mean_f = index_update(self.mean_prev.value, index[ind], mean_f)
+            #B = index_update(self.hessian_approx.value, index[ind], B)
+            B = self.hessian_approx.value.at[ind].set(B)
+            #jacobian = index_update(self.jacobian_prev.value, index[ind], jacobian)
+            jacobian = self.jacobian_prev.value.at[ind].set(jacobian) 
+            #mean_f = index_update(self.mean_prev.value, index[ind], mean_f)
+            mean_f = self.mean_prev.value.at[ind].set(mean_f)
 
         return mean_f, jacobian, B, (mean_f, jacobian, B)
 
@@ -950,9 +953,12 @@ class VariationalQuasiNewton(QuasiNewtonBase, VariationalInference):
         )
 
         if self.mean_prev.value.shape[0] != mean_f.shape[0]:
-            B = index_update(self.hessian_approx.value, index[ind], B)
-            jacobian = index_update(self.jacobian_prev.value, index[ind], jacobian)
-            mean_f = index_update(self.mean_prev.value, index[ind], mean_f)
+            #B = index_update(self.hessian_approx.value, index[ind], B)
+            B = self.hessian_approx.value.at[ind].set(B)
+            #jacobian = index_update(self.jacobian_prev.value, index[ind], jacobian)
+            jacobian = self.jacobian_prev.value.at[ind].set(jacobian)
+            #mean_f = index_update(self.mean_prev.value, index[ind], mean_f)
+            mean_f = self.mean_prev.value.at[ind].set(mean_f)
 
         return mean_f, jacobian, B[:, :self.func_dim, :self.func_dim], (mean_var, jacobian_mean_var, B)
 
@@ -1005,9 +1011,13 @@ class ExpectationPropagationQuasiNewton(QuasiNewtonBase, ExpectationPropagation)
         hessian = scale_factor @ B[:, :self.func_dim, :self.func_dim]
 
         if self.mean_prev.value.shape[0] != cav_mean_f.shape[0]:
-            B = index_update(self.hessian_approx.value, index[ind], B)
-            jacobian = index_update(self.jacobian_prev.value, index[ind], jacobian)
-            cav_mean_f = index_update(self.mean_prev.value, index[ind], cav_mean_f)
+            #B = index_update(self.hessian_approx.value, index[ind], B)
+            B = self.hessian_approx.value.at[ind].set(B)
+            #jacobian = index_update(self.jacobian_prev.value, index[ind], jacobian)
+            jacobian = self.jacobian_prev.value.at[ind].set(jacobian) 
+            #cav_mean_f = index_update(self.mean_prev.value, index[ind], cav_mean_f)
+            cav_mean_f = self.mean_prev.value.at[ind].set(cav_mean_f)
+
 
         return cav_mean_f, jacobian, hessian, (cavity_mean_var, jacobian_unscaled_mean_var, B)
 
@@ -1117,8 +1127,11 @@ class PosteriorLinearisation2ndOrderQuasiNewton(QuasiNewtonBase, PosteriorLinear
         )
 
         if self.mean_prev.value.shape[0] != mean_f.shape[0]:
-            B = index_update(self.hessian_approx.value, index[ind], B)
-            jacobian = index_update(self.jacobian_prev.value, index[ind], jacobian)
-            mean_f = index_update(self.mean_prev.value, index[ind], mean_f)
+            #B = index_update(self.hessian_approx.value, index[ind], B)
+            B = self.hessian_approx.value.at[ind].set(B)
+            #jacobian = index_update(self.jacobian_prev.value, index[ind], jacobian)
+            jacobian = self.jacobian_prev.value.at[ind].set(jacobian) 
+            #mean_f = index_update(self.mean_prev.value, index[ind], mean_f)
+            mean_f = self.mean_prev.value.at[ind].set(mean_f)
 
         return mean_f, jacobian, B[:, :self.func_dim, :self.func_dim], (mean_var, jacobian_mean_var, B)

--- a/bayesnewton/kernels.py
+++ b/bayesnewton/kernels.py
@@ -2,7 +2,7 @@ import objax
 from jax import vmap
 import jax.numpy as np
 from jax.scipy.linalg import cho_factor, cho_solve, block_diag, expm
-from jax.ops import index_add, index
+#from jax.ops import index_add, index
 from .utils import scaled_squared_euclid_dist, softplus, softplus_inv, rotation_matrix
 from warnings import warn
 
@@ -1587,11 +1587,13 @@ class Independent(Kernel):
     def K(self, X, X2):
         zeros = np.zeros(self.num_kernels)
         K0 = self.kernel0.K(X, X2)
-        index_vector = index_add(zeros, index[0], 1.)
+        #index_vector = index_add(zeros, index[0], 1.)
+        index_vector = index_vector.at[0].add(1.)
         Kstack = np.kron(K0, np.diag(index_vector))
         for i in range(1, self.num_kernels):
             kerneli = eval("self.kernel" + str(i))
-            index_vector = index_add(zeros, index[i], 1.)
+            #index_vector = index_add(zeros, index[i], 1.)
+            index_vector = index_vector.at[i].add(1.)
             Kstack += np.kron(kerneli.K(X, X2), np.diag(index_vector))
         return Kstack
 

--- a/bayesnewton/kernels.py
+++ b/bayesnewton/kernels.py
@@ -2,7 +2,6 @@ import objax
 from jax import vmap
 import jax.numpy as np
 from jax.scipy.linalg import cho_factor, cho_solve, block_diag, expm
-#from jax.ops import index_add, index
 from .utils import scaled_squared_euclid_dist, softplus, softplus_inv, rotation_matrix
 from warnings import warn
 
@@ -1587,12 +1586,10 @@ class Independent(Kernel):
     def K(self, X, X2):
         zeros = np.zeros(self.num_kernels)
         K0 = self.kernel0.K(X, X2)
-        #index_vector = index_add(zeros, index[0], 1.)
         index_vector = index_vector.at[0].add(1.)
         Kstack = np.kron(K0, np.diag(index_vector))
         for i in range(1, self.num_kernels):
             kerneli = eval("self.kernel" + str(i))
-            #index_vector = index_add(zeros, index[i], 1.)
             index_vector = index_vector.at[i].add(1.)
             Kstack += np.kron(kerneli.K(X, X2), np.diag(index_vector))
         return Kstack

--- a/bayesnewton/likelihoods.py
+++ b/bayesnewton/likelihoods.py
@@ -1,7 +1,6 @@
 import objax
 import jax.numpy as np
 from jax import grad, jacrev, vmap
-#from jax.ops import index_add, index
 from jax.scipy.special import erf, gammaln, logsumexp
 from jax.scipy.linalg import cholesky, cho_solve, inv
 from jax.nn import softmax
@@ -2321,7 +2320,6 @@ class Softmax(MultiLatentLikelihood, GeneralisedGaussNewtonMixin):
         TODO: fix / figure out
         """
         y_hot = np.zeros([self.num_classes, 1], dtype=float)
-        #y_hot = index_add(y_hot, index[y.astype(int)], 1.)
         y_hot = y_hot.at[y.astype(int)].add(1.)
         E, C = self.conditional_moments(f)
         cholC = cholesky(C + 1e-8 * np.eye(C.shape[0]), lower=True)

--- a/bayesnewton/likelihoods.py
+++ b/bayesnewton/likelihoods.py
@@ -1,7 +1,7 @@
 import objax
 import jax.numpy as np
 from jax import grad, jacrev, vmap
-from jax.ops import index_add, index
+#from jax.ops import index_add, index
 from jax.scipy.special import erf, gammaln, logsumexp
 from jax.scipy.linalg import cholesky, cho_solve, inv
 from jax.nn import softmax
@@ -2321,7 +2321,8 @@ class Softmax(MultiLatentLikelihood, GeneralisedGaussNewtonMixin):
         TODO: fix / figure out
         """
         y_hot = np.zeros([self.num_classes, 1], dtype=float)
-        y_hot = index_add(y_hot, index[y.astype(int)], 1.)
+        #y_hot = index_add(y_hot, index[y.astype(int)], 1.)
+        y_hot = y_hot.at[y.astype(int)].add(1.)
         E, C = self.conditional_moments(f)
         cholC = cholesky(C + 1e-8 * np.eye(C.shape[0]), lower=True)
         V = inv(cholC) @ (y_hot - E)  # cannot use a solve here since cholC is triangular

--- a/bayesnewton/ops.py
+++ b/bayesnewton/ops.py
@@ -1,6 +1,5 @@
 import jax.numpy as np
 from jax import vmap
-#from jax.ops import index_add, index_update, index
 from jax.scipy.linalg import cho_factor, cho_solve
 from jax.scipy.linalg import solve as jsc_solve
 from .utils import mvn_logpdf, solve, transpose, inv, inv_vmap
@@ -11,7 +10,6 @@ INV2PI = (2 * math.pi) ** -1
 
 
 def get_diag_and_offdiag_components(num_latents, zeros, i, noise_cov):
-    #temp_vec = index_add(zeros, index[i], 1.)
     temp_vec = zeros.at[i].add(1.)
     temp_mat = temp_vec.reshape(num_latents, num_latents)
     return np.kron(np.diag(noise_cov), temp_mat)  # block-diag
@@ -239,13 +237,11 @@ def parallel_filtering_operator(elem1, elem2):
 
 
 def make_associative_filtering_elements(As, Qs, H, ys, noise_covs, m0, P0):
-    #Qs = index_update(Qs, index[0], P0)  # first element requires different initialisation
     Qs = Qs.set(0).set(P0)  # first element requires different initialisation
     AA, b, C, J, eta = parallel_filtering_element(As, Qs, H, noise_covs, ys)
     # modify initial b to account for m0 (not needed if m0=zeros)
     S = H @ Qs[0] @ H.T + noise_covs[0]
     K0 = solve(S, H @ Qs[0]).T
-    #b = index_add(b, index[0], m0 - K0 @ H @ m0)
     b = b.at[0].add(m0 - K0 @ H @ m0)
     return AA, b, C, J, eta
 
@@ -450,7 +446,6 @@ def kalman_filter_pairs(dt, kernel, y, noise_cov, mask=None, parallel=False):
 def _sequential_kf_mf(As, Qs, H, ys, noise_covs, m0, P0, masks, block_index):
 
     def build_block_diag(P_blocks):
-        #P = index_add(Pzeros, index[block_index], P_blocks.flatten())
         P = Pzeros.at[block_index].add(P_blocks.flatten())
         return P
 
@@ -492,7 +487,6 @@ def _sequential_kf_mf(As, Qs, H, ys, noise_covs, m0, P0, masks, block_index):
 def parallel_filtering_element_mf_(A, Q, H, noise_cov, y, block_index):
 
     def build_block_diag(P_blocks):
-        #P = index_add(Pzeros, index[block_index], P_blocks.flatten())
         P = Pzeros.at[block_index].add(P_blocks.flatten())
         return P
 
@@ -549,7 +543,6 @@ def parallel_filtering_operator_mf(elem1, elem2):
 def make_associative_filtering_elements_mf(As, Qs, H, ys, noise_covs, m0, P0, block_index):
 
     def build_block_diag(P_blocks):
-        #P = index_add(Pzeros, index[block_index], P_blocks.flatten())
         P = Pzeros.at[block_index].add(P_blocks.flatten())
         return P
 
@@ -561,7 +554,6 @@ def make_associative_filtering_elements_mf(As, Qs, H, ys, noise_covs, m0, P0, bl
     state_dim = num_latents * sub_state_dim
     Pzeros = np.zeros([state_dim, state_dim])
 
-    #Qs = index_update(Qs, index[0], P0)  # first element requires different initialisation
     Qs = Qs.at[0].set(P0)  # first element requires different initialisation
     AA, b, C, J, eta = parallel_filtering_element_mf(As, Qs, H, noise_covs, ys, block_index)
     # modify initial b to account for m0 (not needed if m0=zeros)
@@ -569,7 +561,6 @@ def make_associative_filtering_elements_mf(As, Qs, H, ys, noise_covs, m0, P0, bl
     Qs0 = build_block_diag(Qs[0])
     S = H @ Qs0 @ H.T + noise_covs[0]
     K0 = solve(S, H @ Qs0).T
-    #b = index_add(b, index[0], get_block_mean(m0 - K0 @ (H @ m0)))
     b = b.at[0].add(get_block_mean(m0 - K0 @ (H @ m0)))
     return AA, b, C, J, eta
 
@@ -578,7 +569,6 @@ def _parallel_kf_mf(As, Qs, H, ys, noise_covs, m0, P0, masks, block_index):
 
     @vmap
     def build_block_diag(P_blocks):
-        #P = index_add(Pzeros, index[block_index], P_blocks.flatten())
         P = Pzeros.at[0].add(P_blocks.flatten())
         return P
 
@@ -640,7 +630,6 @@ def kalman_filter_meanfield(dt, kernel, y, noise_cov, mask=None, parallel=False,
 def _sequential_rts_mf(fms, fPs, As, Qs, H, return_full, block_index):
 
     def build_block_diag(P_blocks):
-        #P = index_add(Pzeros, index[block_index], P_blocks.flatten())
         P = Pzeros.at[block_index].add(P_blocks.flatten())
         return P
 
@@ -677,7 +666,6 @@ def _parallel_rts_mf(fms, fPs, As, Qs, H, return_full, block_index):
 
     @vmap
     def build_block_diag(P_blocks):
-        #P = index_add(Pzeros, index[block_index], P_blocks.flatten())
         P = Pzeros.at[block_index].add(P_blocks.flatten())
         return P
 
@@ -739,7 +727,6 @@ def _sequential_kf_pairs_mf(As, Qs, ys, noise_covs, m0, P0, block_index):
 
     def build_block_diag(P_blocks):
         P = np.zeros([state_dim, state_dim])
-        #P = index_add(P, index[block_index], P_blocks.flatten())
         P = P.at[block_index].add(P_blocks.flatten())
         return P
 

--- a/bayesnewton/utils.py
+++ b/bayesnewton/utils.py
@@ -1,7 +1,6 @@
 import jax.numpy as np
 import numpy as nnp
 from jax import vmap
-#from jax.ops import index_add, index, index_update
 from jax.scipy.linalg import cholesky, cho_factor, cho_solve
 from jax.scipy.special import gammaln
 from jax.lax import scan
@@ -222,9 +221,6 @@ def compute_conditional_statistics(x_test, x, kernel, ind):
 def sum_natural_params_by_group(carry, inputs):
     ind_m, nat1_m, nat2_m = inputs
     nat1s, nat2s, count = carry
-    #nat1s = index_add(nat1s, index[ind_m], nat1_m)
-    #nat2s = index_add(nat2s, index[ind_m], nat2_m)
-    #count = index_add(count, index[ind_m], 1.0)
     nat1s = nat1s.at[ind_m].add(nat1_m)
     nat2s = nat2s.at[ind_m].add(nat2_m)
     count = count.at[ind_m].add(1.0)
@@ -234,7 +230,6 @@ def sum_natural_params_by_group(carry, inputs):
 def count_indices(carry, inputs):
     ind_m = inputs
     count = carry
-    #count = index_add(count, index[ind_m], 1.0)
     count = count.at[ind_m].add(1.0)
     return count, 0.
 
@@ -675,20 +670,15 @@ def balance(F: np.ndarray,
             F, d, i = carry
 
             tmp = F[:, i]
-            #tmp = index_update(tmp, index[i], 0.)
             tmp = tmp.at[i].set(0.)
             c = np.linalg.norm(tmp, 2)
             tmp2 = F[i, :]
-            #tmp2 = index_update(tmp2, index[i], 0.)
             tmp2 = tmp2.at[i].set(0.)
 
             r = np.linalg.norm(tmp2, 2)
             f = np.sqrt(r / c)
-            #d = index_update(d, index[i], d[i] * f)
             d = d.at[i].set(d[i] * f)
-            #F = index_update(F, index[:, i], F[:, i] * f)
             F = F.at[:,i].set(F[:, i] * f)
-            #F = index_update(F, index[i, :], F[i, :] / f)
             F = F.at[i,:].set(F[i, :] / f)
             return (F, d, i+1), d
 

--- a/bayesnewton/utils.py
+++ b/bayesnewton/utils.py
@@ -1,7 +1,7 @@
 import jax.numpy as np
 import numpy as nnp
 from jax import vmap
-from jax.ops import index_add, index, index_update
+#from jax.ops import index_add, index, index_update
 from jax.scipy.linalg import cholesky, cho_factor, cho_solve
 from jax.scipy.special import gammaln
 from jax.lax import scan
@@ -222,16 +222,20 @@ def compute_conditional_statistics(x_test, x, kernel, ind):
 def sum_natural_params_by_group(carry, inputs):
     ind_m, nat1_m, nat2_m = inputs
     nat1s, nat2s, count = carry
-    nat1s = index_add(nat1s, index[ind_m], nat1_m)
-    nat2s = index_add(nat2s, index[ind_m], nat2_m)
-    count = index_add(count, index[ind_m], 1.0)
+    #nat1s = index_add(nat1s, index[ind_m], nat1_m)
+    #nat2s = index_add(nat2s, index[ind_m], nat2_m)
+    #count = index_add(count, index[ind_m], 1.0)
+    nat1s = nat1s.at[ind_m].add(nat1_m)
+    nat2s = nat2s.at[ind_m].add(nat2_m)
+    count = count.at[ind_m].add(1.0)
     return (nat1s, nat2s, count), 0.
 
 
 def count_indices(carry, inputs):
     ind_m = inputs
     count = carry
-    count = index_add(count, index[ind_m], 1.0)
+    #count = index_add(count, index[ind_m], 1.0)
+    count = count.at[ind_m].add(1.0)
     return count, 0.
 
 
@@ -671,17 +675,21 @@ def balance(F: np.ndarray,
             F, d, i = carry
 
             tmp = F[:, i]
-            tmp = index_update(tmp, index[i], 0.)
+            #tmp = index_update(tmp, index[i], 0.)
+            tmp = tmp.at[i].set(0.)
             c = np.linalg.norm(tmp, 2)
             tmp2 = F[i, :]
-            tmp2 = index_update(tmp2, index[i], 0.)
+            #tmp2 = index_update(tmp2, index[i], 0.)
+            tmp2 = tmp2.at[i].set(0.)
 
             r = np.linalg.norm(tmp2, 2)
             f = np.sqrt(r / c)
-            d = index_update(d, index[i], d[i] * f)
-            F = index_update(F, index[:, i], F[:, i] * f)
-            F = index_update(F, index[i, :], F[i, :] / f)
-
+            #d = index_update(d, index[i], d[i] * f)
+            d = d.at[i].set(d[i] * f)
+            #F = index_update(F, index[:, i], F[:, i] * f)
+            F = F.at[:,i].set(F[:, i] * f)
+            #F = index_update(F, index[i, :], F[i, :] / f)
+            F = F.at[i,:].set(F[i, :] / f)
             return (F, d, i+1), d
 
         (F, d, _), d_all = scan(f=loop_over_dims,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-jax==0.2.9
-jaxlib==0.1.60
-objax==1.3.1
+jax==0.4.2
+jaxlib==0.4.2
+objax==1.6.0
 numba
 numpy
 matplotlib


### PR DESCRIPTION
We have been stuck with `jax==0.2.9`, `jaxlib==0.1.60` and `objax==1.3.1` for some years now due to #3 where updating objax/jax caused the model to be compiled twice leading to slowdown. This seems to have been fixed in the most recent jax/objax versions and thus updating Bayes-Newton to use more recent versions of them is sensible.

FIXES #3

Changes due to updates in jax:
* The functions jax.ops.index_update, jax.ops.index_add, which were deprecated in 0.2.22, have been removed. Please use [the .at property on JAX arrays](https://jax.readthedocs.io/en/latest/_autosummary/jax.numpy.ndarray.at.html) instead, e.g., x.at[idx].set(y).