### PR TITLE
Update requirements.txt and deprecated functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ python -m pip install -e .
 
 Running the tests requires additionally a specific version of GPflow to test against:
 ```bash
-python -m pip install pytest
+python -m pip install pytest; deactivate && source venv/bin/activate
 python -m pip install tensorflow==2.10 tensorflow-probability==0.18.0 gpflow==2.5.2
 ```
 

--- a/demos/classification.py
+++ b/demos/classification.py
@@ -3,6 +3,7 @@ import objax
 import numpy as np
 import matplotlib.pyplot as plt
 import time
+import math
 
 np.random.seed(99)
 N = 500  # number of training points
@@ -14,11 +15,11 @@ x1 = 40 * np.random.rand(N//2) + 60
 x = np.concatenate([x0, np.array([50]), x1], axis=0)
 # x = np.linspace(np.min(x), np.max(x), N)
 f = lambda x_: 6 * np.sin(np.pi * x_ / 10.0) / (np.pi * x_ / 10.0 + 1)
-y_ = f(x) + np.math.sqrt(0.05)*np.random.randn(x.shape[0])
+y_ = f(x) + math.sqrt(0.05)*np.random.randn(x.shape[0])
 y = np.sign(y_)
 y[y == -1] = 0
 x_test = np.linspace(np.min(x)-5.0, np.max(x)+5.0, num=500)
-y_test = np.sign(f(x_test) + np.math.sqrt(0.05)*np.random.randn(x_test.shape[0]))
+y_test = np.sign(f(x_test) + math.sqrt(0.05)*np.random.randn(x_test.shape[0]))
 y_test[y_test == -1] = 0
 x_plot = np.linspace(np.min(x)-10.0, np.max(x)+10.0, num=500)
 z = np.linspace(min(x), max(x), num=M)

--- a/demos/positive.py
+++ b/demos/positive.py
@@ -3,6 +3,7 @@ import objax
 import numpy as np
 import matplotlib.pyplot as plt
 import time
+import math
 
 
 def nonlinearity(f_):
@@ -19,9 +20,9 @@ x = 100 * np.random.rand(N)
 # x = np.linspace(np.min(x), np.max(x), N)
 # f = lambda x_: 3 * np.sin(np.pi * x_ / 10.0)
 f = wiggly_time_series
-y = nonlinearity(f(x)) + np.math.sqrt(0.1)*np.random.randn(x.shape[0])
+y = nonlinearity(f(x)) + math.sqrt(0.1)*np.random.randn(x.shape[0])
 x_test = np.linspace(np.min(x), np.max(x), num=500)
-y_test = nonlinearity(f(x_test)) + np.math.sqrt(0.05)*np.random.randn(x_test.shape[0])
+y_test = nonlinearity(f(x_test)) + math.sqrt(0.05)*np.random.randn(x_test.shape[0])
 x_plot = np.linspace(np.min(x)-10.0, np.max(x)+10.0, num=500)
 
 M = 20

--- a/demos/regression.py
+++ b/demos/regression.py
@@ -3,14 +3,14 @@ import objax
 import numpy as np
 import matplotlib.pyplot as plt
 import time
-
+import math
 
 def wiggly_time_series(x_):
     noise_var = 0.2  # true observation noise
     # return 0.25 * (np.cos(0.04*x_+0.33*np.pi) * np.sin(0.2*x_) +
     return (np.cos(0.04*x_+0.33*np.pi) * np.sin(0.2*x_) +
-            np.math.sqrt(noise_var) * np.random.normal(0, 1, x_.shape) +
-            # np.math.sqrt(noise_var) * np.random.uniform(-4, 4, x_.shape) +
+            math.sqrt(noise_var) * np.random.normal(0, 1, x_.shape) +
+            # math.sqrt(noise_var) * np.random.uniform(-4, 4, x_.shape) +
             0.0 * x_)  # 0.02 * x_)
             # 0.0 * x_) + 2.5  # 0.02 * x_)
 

--- a/demos/studentt.py
+++ b/demos/studentt.py
@@ -4,12 +4,12 @@ from jax import vmap
 import numpy as np
 import matplotlib.pyplot as plt
 import time
-
+import math
 
 def wiggly_time_series(x_):
     noise_var = 0.2  # true observation noise scale
     return (np.cos(0.04*x_+0.33*np.pi) * np.sin(0.2*x_) +
-            np.math.sqrt(noise_var) * np.random.standard_t(3., x_.shape) +
+            math.sqrt(noise_var) * np.random.standard_t(3., x_.shape) +
             0.0 * x_)
 
 

--- a/experiments/binary/binary.py
+++ b/experiments/binary/binary.py
@@ -4,6 +4,7 @@ import objax
 import numpy as np
 import time
 import pickle
+import math
 
 print('generating some data ...')
 np.random.seed(99)
@@ -11,7 +12,7 @@ N = 10000  # number of points
 x = np.sort(70 * np.random.rand(N))
 sn = 0.01
 f = lambda x_: 12. * np.sin(4 * np.pi * x_) / (0.25 * np.pi * x_ + 1)
-y_ = f(x) + np.math.sqrt(sn)*np.random.randn(x.shape[0])
+y_ = f(x) + math.sqrt(sn)*np.random.randn(x.shape[0])
 y = np.sign(y_)
 y[y == -1] = 0
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,5 @@ numba
 numpy
 matplotlib
 scipy
-sklearn
+scikit-learn
 pandas

--- a/tests/normaliser_test.py
+++ b/tests/normaliser_test.py
@@ -6,6 +6,7 @@ from bayesnewton.utils import transpose
 from jax import vmap
 import jax.numpy as jnp
 from jax.scipy.linalg import cho_factor
+import math
 
 np.random.seed(3)
 
@@ -13,7 +14,7 @@ np.random.seed(3)
 def wiggly_time_series(x_):
     noise_var = 0.15  # true observation noise
     return (np.cos(0.04*x_+0.33*np.pi) * np.sin(0.2*x_) +
-            np.math.sqrt(noise_var) * np.random.normal(0, 1, x_.shape) +
+            math.sqrt(noise_var) * np.random.normal(0, 1, x_.shape) +
             0.0 * x_)  # 0.02 * x_)
 
 

--- a/tests/test_gp_vs_markovgp_class.py
+++ b/tests/test_gp_vs_markovgp_class.py
@@ -4,14 +4,14 @@ import numpy as np
 from jax.config import config
 config.update("jax_enable_x64", True)
 import pytest
-
+import math
 
 def build_data(N):
     # np.random.seed(12345)
     x = 100 * np.random.rand(N)
     x = np.sort(x)  # since MarkovGP sorts the inputs, they must also be sorted for GP
     f = lambda x_: 6 * np.sin(np.pi * x_ / 10.0) / (np.pi * x_ / 10.0 + 1)
-    y_ = f(x) + np.math.sqrt(0.05) * np.random.randn(x.shape[0])
+    y_ = f(x) + math.sqrt(0.05) * np.random.randn(x.shape[0])
     y = np.sign(y_)
     y[y == -1] = 0
     x = x[:, None]

--- a/tests/test_gp_vs_markovgp_reg.py
+++ b/tests/test_gp_vs_markovgp_reg.py
@@ -4,12 +4,12 @@ import numpy as np
 from jax.config import config
 config.update("jax_enable_x64", True)
 import pytest
-
+import math
 
 def wiggly_time_series(x_):
     noise_var = 0.15  # true observation noise
     return (np.cos(0.04*x_+0.33*np.pi) * np.sin(0.2*x_) +
-            np.math.sqrt(noise_var) * np.random.normal(0, 1, x_.shape))
+            math.sqrt(noise_var) * np.random.normal(0, 1, x_.shape))
 
 
 def build_data(N):

--- a/tests/test_sparsemarkov.py
+++ b/tests/test_sparsemarkov.py
@@ -7,12 +7,12 @@ import matplotlib.pyplot as plt
 from jax.config import config
 config.update("jax_enable_x64", True)
 import pytest
-
+import math
 
 def wiggly_time_series(x_):
     noise_var = 0.15  # true observation noise
     return (np.cos(0.04*x_+0.33*np.pi) * np.sin(0.2*x_) +
-            np.math.sqrt(noise_var) * np.random.normal(0, 1, x_.shape))
+            math.sqrt(noise_var) * np.random.normal(0, 1, x_.shape))
 
 
 def build_data(N):

--- a/tests/test_vs_exact_marg_lik.py
+++ b/tests/test_vs_exact_marg_lik.py
@@ -4,12 +4,13 @@ from bayesnewton.utils import solve
 from jax.config import config
 config.update("jax_enable_x64", True)
 import pytest
+import math
 
 
 def wiggly_time_series(x_):
     noise_var = 0.15  # true observation noise
     return (np.cos(0.04*x_+0.33*np.pi) * np.sin(0.2*x_) +
-            np.math.sqrt(noise_var) * np.random.normal(0, 1, x_.shape))
+            math.sqrt(noise_var) * np.random.normal(0, 1, x_.shape))
 
 
 def build_data(N):

--- a/tests/test_vs_gpflow_class.py
+++ b/tests/test_vs_gpflow_class.py
@@ -7,6 +7,7 @@ config.update("jax_enable_x64", True)
 import pytest
 import tensorflow as tf
 import gpflow
+import math
 
 # TODO: ------- FIX --------
 
@@ -15,7 +16,7 @@ def build_data(N):
     # np.random.seed(12345)
     x = 100 * np.random.rand(N)
     f = lambda x_: 6 * np.sin(np.pi * x_ / 10.0) / (np.pi * x_ / 10.0 + 1)
-    y_ = f(x) + np.math.sqrt(0.05) * np.random.randn(x.shape[0])
+    y_ = f(x) + math.sqrt(0.05) * np.random.randn(x.shape[0])
     y = np.sign(y_)
     y[y == -1] = 0
     x = x[:, None]

--- a/tests/test_vs_gpflow_reg.py
+++ b/tests/test_vs_gpflow_reg.py
@@ -7,12 +7,13 @@ config.update("jax_enable_x64", True)
 import pytest
 import tensorflow as tf
 import gpflow
+import math
 
 
 def wiggly_time_series(x_):
     noise_var = 0.15  # true observation noise
     return (np.cos(0.04*x_+0.33*np.pi) * np.sin(0.2*x_) +
-            np.math.sqrt(noise_var) * np.random.normal(0, 1, x_.shape))
+            math.sqrt(noise_var) * np.random.normal(0, 1, x_.shape))
 
 
 def build_data(N):


### PR DESCRIPTION
This package has been very useful, thanks for making it available! Here are a few small changes cleaning up for installation/testing:

1. Currently, `requirements.txt` installs `sklearn` -- [this is now deprecated](https://pypi.org/project/sklearn/) and one must install `scikit-learn` instead.
2. When using venv as in the README, one needs to [resource the venv before running tests with PyTest.](https://stackoverflow.com/a/54597424)
3. There are several references to `np.math` which was recently deprecated in `numpy`, as it simply re-exported the native Python `math` class. I replaced these with `math`.

There are several tests that fail, but it seems like these are generally either known or part of ongoing issues/pull requests.