### PR TITLE
Removed numba requirement und bumped jax to 0.4.14 for native windows support

### DIFF
--- a/bayesnewton/inference.py
+++ b/bayesnewton/inference.py
@@ -1,6 +1,6 @@
 import objax
 import jax.numpy as np
-from jax import vmap
+from jax import vmap, Array
 from .utils import (
     diag,
     transpose,
@@ -48,9 +48,10 @@ class InferenceMixin(abc.ABC):
     TODO: re-derive and re-implement QuasiNewton methods
     TODO: move as much of the generic functionality as possible from the base model class to this class.
     """
+
     num_data: float
-    Y: np.DeviceArray
-    ind: np.DeviceArray
+    Y: Array
+    ind: Array
     pseudo_likelihood: GaussianDistribution
     posterior_mean: objax.StateVar
     posterior_var: objax.StateVar
@@ -231,8 +232,8 @@ class ExpectationPropagation(InferenceMixin):
     compute_full_pseudo_lik: classmethod
     compute_log_lik: classmethod
     compute_ep_energy_terms: classmethod
-    mask_y: np.DeviceArray
-    mask_pseudo_y: np.DeviceArray
+    mask_y: Array
+    mask_pseudo_y: Array
 
     def update_variational_params(self, batch_ind=None, lr=1., cubature=None, ensure_psd=True, **kwargs):
         """
@@ -332,8 +333,8 @@ class PosteriorLinearisation(InferenceMixin):
     # TODO: remove these when possible
     cavity_distribution: classmethod
     compute_full_pseudo_lik: classmethod
-    mask_y: np.DeviceArray
-    mask_pseudo_y: np.DeviceArray
+    mask_y: Array
+    mask_pseudo_y: Array
 
     def update_variational_params(self, batch_ind=None, lr=1., cubature=None, **kwargs):
         """
@@ -432,8 +433,8 @@ class PosteriorLinearisation2ndOrder(PosteriorLinearisation):
     """
     # TODO: remove these when possible
     compute_full_pseudo_lik: classmethod
-    mask_y: np.DeviceArray
-    mask_pseudo_y: np.DeviceArray
+    mask_y: Array
+    mask_pseudo_y: Array
 
     def update_variational_params(self, batch_ind=None, lr=1., cubature=None, ensure_psd=True, **kwargs):
         """
@@ -574,8 +575,8 @@ class PosteriorLinearisation2ndOrderGaussNewton(PosteriorLinearisation):
     """
     # TODO: remove these when possible
     compute_full_pseudo_lik: classmethod
-    mask_y: np.DeviceArray
-    mask_pseudo_y: np.DeviceArray
+    mask_y: Array
+    mask_pseudo_y: Array
 
     def update_variational_params(self, batch_ind=None, lr=1., cubature=None, **kwargs):
         """

--- a/bayesnewton/utils.py
+++ b/bayesnewton/utils.py
@@ -4,6 +4,7 @@ from jax import vmap
 from jax.scipy.linalg import cholesky, cho_factor, cho_solve
 from jax.scipy.special import gammaln
 from jax.lax import scan
+# from matplotlib._png import read_png
 import math
 
 LOG2PI = math.log(2 * math.pi)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,7 @@
-jax==0.4.2
-jaxlib==0.4.2
-objax==1.6.0
-numba
+jax==0.4.14
+jaxlib==0.4.14
+objax==1.7.0
+tensorflow_probability==0.20.1
 numpy
 matplotlib
 scipy
-sklearn
-pandas

--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,13 @@ setup(
     version=__version__,
     packages=find_packages(),
     python_requires='>=3.6',
+    install_requires=[
+        "jax==0.4.14",
+        "jaxlib==0.4.14",
+        "objax==1.7.0",
+        "tensorflow_probability==0.20.1",
+        "numpy>=1.22"
+    ],
     url='https://github.com/AaltoML/BayesNewton',
     license='Apache-2.0',
 )

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(
         "jax==0.4.14",
         "jaxlib==0.4.14",
         "objax==1.7.0",
-        "tensorflow_probability==0.20.1",
+        "tensorflow_probability==0.21",
         "numpy>=1.22"
     ],
     url='https://github.com/AaltoML/BayesNewton',


### PR DESCRIPTION
Removed numba as this was a constant source of installation errors. This was justified, as it was only used for one function which was never used in bayesnewton.